### PR TITLE
Typo in KPIC2 default feature param ranges

### DIFF
--- a/R/features-optimize-kpic2.R
+++ b/R/features-optimize-kpic2.R
@@ -48,4 +48,4 @@ generateFeatureOptPSetKPIC2 <- function(...)
                 kmeans = TRUE))
 }
 
-getDefFeaturesOptParamRangesKPIC2 <- function() list(min_width = 3)
+getDefFeaturesOptParamRangesKPIC2 <- function() list(min_width = c(3, Inf))


### PR DESCRIPTION
Thanks for the great package Rick! I noticed a small typo when running parameter optimizations for KPIC2. A default range was missing for `min_width` which would cause an error when the line below was executed:

https://github.com/rickhelmus/patRoon/blob/b5caee3624458cde0d8b07e5832b6fc26c8c7e6e/R/doe-optimizer.R#L247

