### PR TITLE
Add visual clue to checkFeatures()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,10 @@ Authors@R: c(
     person("Bas", "van de Velde",
            role = "ctb",
            comment = c(ORCID = "0000-0003-1292-3251"),
+    ),
+    person("Leon", "Saal",
+           role = "ctb",
+           comment = c(ORCID = "0000-0002-3522-7729"),
     ))
 Description: Provides an easy-to-use interface to a mass spectrometry based
     non-target analysis workflow. Various (open-source) tools are combined

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 
 * `generateTPsLibrary()`/`generateTPsLibraryFormula()` any TPs that are equal to the parent and are from a generation>1 are now removed
 * Added clarification in `generateCompoundsSIRIUS()` documentation that formula candidates without structure assignment are omitted (suggested by Nienke Meekel)
+* Added visual clue to `checkFeatures()` to see whether a feature is marked to be kept (pull request #117 as suggested by Leon Saal)
 
 ## Fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 * Fixed: `reAverage = TRUE` was not handled correctly for the `delete()` method for `MSPeakListsSet`
 * Speed up 'unsetting' of large formulas/compounds objects, which affects eg plotting TP similarities, annotatedPeakList() etc (reported by Alessia Ore)
 * `report()`: correctly handle removed suspect hits while reporting TP similarities (reported by Alessia Ore)
+* Added visual clue to `checkFeatures()` and `checkComponents()` to see whether a feature or component is marked to be removed (pull request #117 as suggested by Leon Saal)
+
 
 # patRoon 2.3.3
 
@@ -14,7 +16,6 @@
 
 * `generateTPsLibrary()`/`generateTPsLibraryFormula()` any TPs that are equal to the parent and are from a generation>1 are now removed
 * Added clarification in `generateCompoundsSIRIUS()` documentation that formula candidates without structure assignment are omitted (suggested by Nienke Meekel)
-* Added visual clue to `checkFeatures()` to see whether a feature is marked to be kept (pull request #117 as suggested by Leon Saal)
 
 ## Fixes
 

--- a/R/check_components.R
+++ b/R/check_components.R
@@ -118,7 +118,8 @@ checkComponentsInterface$methods(
         rp <- rValues$removePartially[[rValues$currentPrimSel]]
         cmp <- if (!is.null(rp)) delete(components, j = rp) else components
         
-        withr::with_par(list(mar = c(4, 4, 0.1, 1), cex = 1.5), {
+        bg <- if (rValues$currentPrimSel %in% rValues$removeFully) RColorBrewer::brewer.pal(9, "Reds")[[1]] else "white"
+        withr::with_par(list(mar = c(4, 4, 0.1, 1), cex = 1.5, bg = bg), {
             if (!rValues$currentPrimSel %in% names(cmp))
             {
                 # may happen if all fGroups are disabled

--- a/R/check_features.R
+++ b/R/check_features.R
@@ -264,16 +264,8 @@ checkFeaturesInterface$methods(
         
         ep <- getDefEICParams(topMost = if (rValues$fGroupPlotMode == "all") NULL else 1,
                               topMostByRGroup = rValues$fGroupPlotMode == "topMostByRGroup")
-        tbl <- rhandsontable::hot_to_r(input$primaryHot)
-        tblRow <- match(rValues$currentPrimSel, tbl[[1]])
-
-        if (!is.na(tblRow))
-            keep <- tbl[tblRow, ]$keep
-        else
-            keep <- 1
-
-        bg = c(RColorBrewer::brewer.pal(9, "Reds")[[1]], "white")[[keep+1]]
-
+        
+        bg <- if (rValues$currentPrimSel %in% rValues$removeFully) RColorBrewer::brewer.pal(9, "Reds")[[1]] else "white"
         withr::with_par(list(mar = c(4, 4, 0.1, 1), cex = 1.5, bg = bg), {
             plotChroms(fg, EICs = EICs, colourBy = "rGroups", showPeakArea = TRUE, EICParams = ep,
                        showFGroupRect = FALSE, title = "", retMin = rValues$settings$retUnit == "min")

--- a/R/check_features.R
+++ b/R/check_features.R
@@ -264,7 +264,17 @@ checkFeaturesInterface$methods(
         
         ep <- getDefEICParams(topMost = if (rValues$fGroupPlotMode == "all") NULL else 1,
                               topMostByRGroup = rValues$fGroupPlotMode == "topMostByRGroup")
-        withr::with_par(list(mar = c(4, 4, 0.1, 1), cex = 1.5), {
+        tbl <- rhandsontable::hot_to_r(input$primaryHot)
+        tblRow <- match(rValues$currentPrimSel, tbl[[1]])
+
+        if (!is.na(tblRow))
+            keep <- tbl[tblRow, ]$keep
+        else
+            keep <- 2
+
+        bg = c(RColorBrewer::brewer.pal(3, "Reds")[[1]], RColorBrewer::brewer.pal(3, "Greens")[[1]], "white")[[keep+1]]
+
+        withr::with_par(list(mar = c(4, 4, 0.1, 1), cex = 1.5, bg = bg), {
             plotChroms(fg, EICs = EICs, colourBy = "rGroups", showPeakArea = TRUE, EICParams = ep,
                        showFGroupRect = FALSE, title = "", retMin = rValues$settings$retUnit == "min")
         })
@@ -477,5 +487,5 @@ predictCheckFeaturesSession <- function(fGroups, session, model = NULL, overWrit
     rmf <- gNames[preds[preds$Pred_Class %in% c("BAD", "Fail"), "EIC"]]
     saveCheckSession(list(removeFully = rmf, removePartially = list()), session, fGroups[, rmf], "featureGroups")
     
-    invisible(NULL)
+    invisible(preds)
 }

--- a/R/check_features.R
+++ b/R/check_features.R
@@ -270,9 +270,9 @@ checkFeaturesInterface$methods(
         if (!is.na(tblRow))
             keep <- tbl[tblRow, ]$keep
         else
-            keep <- 2
+            keep <- 1
 
-        bg = c(RColorBrewer::brewer.pal(3, "Reds")[[1]], RColorBrewer::brewer.pal(3, "Greens")[[1]], "white")[[keep+1]]
+        bg = c(RColorBrewer::brewer.pal(9, "Reds")[[1]], "white")[[keep+1]]
 
         withr::with_par(list(mar = c(4, 4, 0.1, 1), cex = 1.5, bg = bg), {
             plotChroms(fg, EICs = EICs, colourBy = "rGroups", showPeakArea = TRUE, EICParams = ep,
@@ -452,6 +452,8 @@ getMCTrainData <- function(fGroups, session)
 #'   remove unwanted feature groups by \code{\link[=filter,featureGroups-method]{filter}}.
 #' @param model The model that was created with \pkg{MetaClean} and that should be used to predict pass/fail data. If
 #'   \code{NULL}, the example model of the \pkg{MetaCleanData} package is used.
+#' @return A dataframe with the class predictions as well as the associated probabilities for each EIC as returned by the \code{MetaClean::getPredicitons} function. 
+#'   The dataframe has the four columns: EIC, Pred_Class, Pred_Prob_Pass, Pred_Prob_Fail.
 #' @rdname check-GUI
 #' @export
 predictCheckFeaturesSession <- function(fGroups, session, model = NULL, overWrite = FALSE)

--- a/man/check-GUI.Rd
+++ b/man/check-GUI.Rd
@@ -82,6 +82,10 @@ function will stop with an error message.}
 \item{model}{The model that was created with \pkg{MetaClean} and that should be used to predict pass/fail data. If
 \code{NULL}, the example model of the \pkg{MetaCleanData} package is used.}
 }
+\value{
+A dataframe with the class predictions as well as the associated probabilities for each EIC as returned by the \code{MetaClean::getPredicitons} function. 
+  The dataframe has the four columns: EIC, Pred_Class, Pred_Prob_Pass, Pred_Prob_Fail.
+}
 \description{
 These functions provide interactive utilities to explore and review workflow data using a \pkg{\link{shiny}}
 graphical user interface (GUI). In addition, unsatisfactory data (\emph{e.g.} noise identified as a feature and

--- a/man/patRoon-package.Rd
+++ b/man/patRoon-package.Rd
@@ -101,6 +101,7 @@ Other contributors:
   \item Andrea Brunner (\href{https://orcid.org/0000-0002-2801-1751}{ORCID}) [contributor]
   \item Emma Schymanski (\href{https://orcid.org/0000-0001-6868-8145}{ORCID}) [contributor]
   \item Bas van de Velde (\href{https://orcid.org/0000-0003-1292-3251}{ORCID}) [contributor]
+  \item Leon Saal (\href{https://orcid.org/0000-0002-3522-7729}{ORCID}) [contributor]
 }
 
 }


### PR DESCRIPTION
Hi Rick,

to speed up the `checkFeatures()`-workflow I added a change of background color of the EIC-plot, depending on whether a feature is marked as kept or not. Especially if you use `predictCheckFeaturesSession()` it's helpful, I think.
Additionally I implemented, that `predictCheckFeaturesSession()` now returns the predictions made by the model, so its easier to inspect edge cases with a probability close to 0.5.
I hope you also deem this to be useful.

Kind regards,

Leon